### PR TITLE
Polaroid studio: canvas orientation, split captions, batch cutting borders

### DIFF
--- a/public/tools/polaroid-studio.html
+++ b/public/tools/polaroid-studio.html
@@ -777,6 +777,56 @@
                 </p>
               </section>
 
+              <section>
+                <label class="block text-[10px] font-black uppercase tracking-wider text-slate-400 mb-3"
+                  >04. Cutting Borders</label
+                >
+                <div class="flex items-center justify-between p-2 bg-slate-50 rounded-lg border border-slate-100">
+                  <div class="flex flex-col">
+                    <span class="text-[11px] font-bold text-slate-700 leading-tight">Guides Per Photo</span>
+                    <span class="text-[9px] text-slate-400 font-medium leading-tight"
+                      >Thin lines to cut along after printing</span
+                    >
+                  </div>
+                  <div class="relative inline-block w-10 align-middle select-none transition duration-200 ease-in">
+                    <input
+                      type="checkbox"
+                      name="batchGuideToggle"
+                      id="batchGuideToggle"
+                      onchange="updateBatchGuides()"
+                      class="toggle-checkbox absolute block w-5 h-5 rounded-full bg-white border-4 appearance-none cursor-pointer outline-none"
+                    />
+                    <label
+                      for="batchGuideToggle"
+                      class="toggle-label block overflow-hidden h-5 rounded-full bg-gray-300 cursor-pointer"
+                    ></label>
+                  </div>
+                </div>
+                <div id="batchGuideOptions" class="mt-3 space-y-2 hidden">
+                  <select
+                    id="batchGuideStyle"
+                    onchange="renderBatchSheet()"
+                    class="w-full px-4 py-3 bg-slate-50 border border-slate-100 rounded-xl text-xs font-bold uppercase tracking-widest cursor-pointer outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+                  >
+                    <option value="solid">Solid Outline</option>
+                    <option value="dashed">Dashed Outline</option>
+                    <option value="marks">Corner Crop Marks</option>
+                  </select>
+                  <select
+                    id="batchGuideTone"
+                    onchange="renderBatchSheet()"
+                    class="w-full px-4 py-3 bg-slate-50 border border-slate-100 rounded-xl text-xs font-bold uppercase tracking-widest cursor-pointer outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+                  >
+                    <option value="light">Light Grey Line</option>
+                    <option value="mid">Medium Grey Line</option>
+                    <option value="dark">Black Line</option>
+                  </select>
+                  <p class="text-[9px] text-slate-400 italic text-center">
+                    Drawn just inside each photo so lines never overlap neighbours
+                  </p>
+                </div>
+              </section>
+
               <section class="pt-4 border-t border-slate-50 flex flex-col gap-2">
                 <button
                   onclick="exportBatchSheet()"
@@ -891,6 +941,10 @@
       const cuttingGuideToggle = document.getElementById("cuttingGuideToggle");
       const batchSpacingRange = document.getElementById("batchSpacingRange");
       const batchSpacingVal = document.getElementById("batchSpacingVal");
+      const batchGuideToggle = document.getElementById("batchGuideToggle");
+      const batchGuideOptions = document.getElementById("batchGuideOptions");
+      const batchGuideStyle = document.getElementById("batchGuideStyle");
+      const batchGuideTone = document.getElementById("batchGuideTone");
 
       const brightRange = document.getElementById("brightRange");
       const contrastRange = document.getElementById("contrastRange");
@@ -1451,6 +1505,44 @@
         renderBatchSheet();
       }
 
+      function updateBatchGuides() {
+        batchGuideOptions.classList.toggle("hidden", !batchGuideToggle.checked);
+        renderBatchSheet();
+      }
+
+      const GUIDE_TONES = { light: "#d1d5db", mid: "#9ca3af", dark: "#111827" };
+
+      // Cut guides sit just *inside* each photo's box so that neighbouring items
+      // (spacing 0) never double up on a shared line, and nothing bleeds off the sheet.
+      function drawCutGuide(x, y, w, h) {
+        if (!batchGuideToggle.checked) return;
+        const lw = Math.max(1, Math.round(0.15 * PMM)); // ~0.15mm hairline
+        const o = lw / 2;
+        batchCtx.save();
+        batchCtx.strokeStyle = GUIDE_TONES[batchGuideTone.value] || GUIDE_TONES.light;
+        batchCtx.lineWidth = lw;
+        if (batchGuideStyle.value === "marks") {
+          const len = Math.min(w, h) * 0.1;
+          const corners = [
+            [x + o, y + o, 1, 1],
+            [x + w - o, y + o, -1, 1],
+            [x + o, y + h - o, 1, -1],
+            [x + w - o, y + h - o, -1, -1],
+          ];
+          batchCtx.beginPath();
+          corners.forEach(([cx, cy, dx, dy]) => {
+            batchCtx.moveTo(cx + dx * len, cy);
+            batchCtx.lineTo(cx, cy);
+            batchCtx.lineTo(cx, cy + dy * len);
+          });
+          batchCtx.stroke();
+        } else {
+          if (batchGuideStyle.value === "dashed") batchCtx.setLineDash([lw * 4, lw * 3]);
+          batchCtx.strokeRect(x + o, y + o, w - lw, h - lw);
+        }
+        batchCtx.restore();
+      }
+
       function updateBatchSheetSize() {
         const sheet = SHEETS[batchSheetSelector.value];
         batchCanvas.width = sheet.w * PMM;
@@ -1482,6 +1574,7 @@
           // Don't draw if it goes off the bottom of the sheet
           if (curY + item.h <= batchCanvas.height) {
             batchCtx.drawImage(item.img, curX, curY);
+            drawCutGuide(curX, curY, item.w, item.h);
             maxRowH = Math.max(maxRowH, item.h);
             curX += item.w + spacing;
           }


### PR DESCRIPTION
Two changes to `public/tools/polaroid-studio.html`.

## Studio editor (687a549)
- **Canvas orientation** — a Portrait/Landscape toggle turns the frame itself. `getConfig()` swaps the format's `w`/`h` (and `realW`/`realH`) and every consumer reads from it, so the canvas changes shape while the photo and captions stay upright. The choice persists across format switches, and print sizing follows (a landscape Classic 600 reports 107mm instead of 88mm on the print sheet).
- **Split captions** — the single caption field is now separate Title and Date fields, each with its own alignment and size. Old saves migrate (`caption`/`textSize` → `title`/`titleSize`).
- **Zoom** now anchors on the center of the photo window rather than the canvas origin, so the framed subject stays put while scaling.

## Batch print (a37edd7)
New **04. Cutting Borders** section so printed sheets are easier to cut apart:
- Toggle (off by default), style — solid outline / dashed outline / corner crop marks, and tone — light grey / medium grey / black.
- Guides are inset by half the line width, so neighbouring items at 0mm spacing don't stack two lines on a shared edge and nothing bleeds off the sheet.
- Drawn into the canvas, so exported sheets include them.

## Testing
Batch guides verified in headless Chrome with generated test polaroids (mixed mini + square sizes, 0mm and 3mm spacing) across all three styles — outlines land on each photo boundary, crop marks sit at the corners, dashed renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUTmtpLXW8295F3tyySAnK